### PR TITLE
Made windows ssh path the default

### DIFF
--- a/NewSecureShell.psm1
+++ b/NewSecureShell.psm1
@@ -6,12 +6,12 @@ function New-SecureShell {
         [string]$SessionHost
     )
     if ($SessionHost) {
-        if ($IsWindows) {
-            # This is the default path to the OpenSSH client on Windows 10
-            return & C:\Windows\System32\OpenSSH\ssh.exe $SessionHost
-        } else {
+        if ($IsLinux -or $IsMacOS) {
             # This is the default path to the OpenSSH client on Linux and maybe Mac?
             return & /usr/bin/ssh $SessionHost
+        } else {
+            # This is the default path to the OpenSSH client on Windows 10
+            return & C:\Windows\System32\OpenSSH\ssh.exe $SessionHost
         }
     }
     return "You must specify a hostname or IP address"


### PR DESCRIPTION
Closes #3 

In Windows 10 the powershell version is currently set to 5.1
which does not define these OS environment variables:

  $IsLinux
  $IsMacOS
  $IsWindows

This causes the executable ssh path to use the Linux/MacOS ssh path.
Mad windows ssh path the default so if the OS variables are not
defined, as in Windows 10 powershell version 5.1 it will use the
windows ssh path.